### PR TITLE
GEN instead of DAOToken for ganache

### DIFF
--- a/migrate-base.js
+++ b/migrate-base.js
@@ -10,8 +10,13 @@ async function migrateBase ({ web3, spinner, confirm, opts, logTx, previousMigra
     const sameDeps = deps.reduce((acc, dep) => addresses[dep] === existing[dep] && acc, true)
     const code = existing[contractName] && (await web3.eth.getCode(existing[contractName]))
     const sameCode = existing[contractName] && deployedBytecode === code
+
+    if (contractName === 'DAOToken') {
+      contractName = 'GEN'
+    }
+
     if (
-      contractName === 'DAOToken' &&
+      contractName === 'GEN' &&
       existing[contractName] &&
       code !== '0x' &&
       !(await confirm(`Found existing GEN (DAOToken) contract, Deploy new instance?`, false))
@@ -46,10 +51,10 @@ async function migrateBase ({ web3, spinner, confirm, opts, logTx, previousMigra
   }
 
   const network = await web3.eth.net.getNetworkType()
-  let DAOToken = '0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf'
+  let GENToken = '0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf'
 
   if (network === 'private') {
-    DAOToken = await deploy(
+    GENToken = await deploy(
       require('@daostack/arc/build/contracts/DAOToken.json'),
       [],
       'DAOstack',
@@ -57,7 +62,7 @@ async function migrateBase ({ web3, spinner, confirm, opts, logTx, previousMigra
       web3.utils.toWei('100000000')
     )
   } else {
-    addresses['GEN'] = DAOToken
+    addresses['GEN'] = GENToken
   }
 
   const ControllerCreator = await deploy(require('@daostack/arc/build/contracts/ControllerCreator.json'))
@@ -71,7 +76,7 @@ async function migrateBase ({ web3, spinner, confirm, opts, logTx, previousMigra
   const GenesisProtocol = await deploy(
     require('@daostack/arc/build/contracts/GenesisProtocol.json'),
     ['DAOToken'],
-    DAOToken
+    GENToken
   )
   await deploy(require('@daostack/arc/build/contracts/SchemeRegistrar.json'))
   await deploy(require('@daostack/arc/build/contracts/UpgradeScheme.json'))

--- a/migration.json
+++ b/migration.json
@@ -1,7 +1,7 @@
 {
   "private": {
     "base": {
-      "DAOToken": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
+      "GEN": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
       "ControllerCreator": "0x5b1869D9A4C187F2EAa108f3062412ecf0526b24",
       "DaoCreator": "0xCfEB869F69431e42cdB54A4F4f105C19C080A601",
       "UController": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B",
@@ -39,25 +39,7 @@
     }
   },
   "kovan": {
-    "base": {
-      "GEN": "0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf",
-      "ControllerCreator": "0xA69a758Ba69d7950D0EBa1d5A0369cD19615D6FF",
-      "DaoCreator": "0x5F16D78245c71dC667a75a7D6c072A5F6991f343",
-      "UController": "0x06D13144685Ae31C8d1004eedc60E8d76C66eAff",
-      "GenesisProtocol": "0x32337118FE4eA5FEb16809374eb6B85b0609752e",
-      "SchemeRegistrar": "0x38830652fc8c749B4E1485f500227b6944563955",
-      "UpgradeScheme": "0xea0EE24517Bb15D6b5E63813a91591926F38Ca0E",
-      "GlobalConstraintRegistrar": "0x1127604d3Acae2Bf87d177123792D4899fd2410b",
-      "ContributionReward": "0x098b1D066cc224593cF996510539692B48b814A1",
-      "AbsoluteVote": "0xfC490CaCCE47728e68CBF03958A955a3fDd58f82",
-      "QuorumVote": "0xDBcaAcf4739f9Fd398150F5d17723C61dD6e19E2",
-      "TokenCapGC": "0x5b30332381E16aF9fb9B3008B8c5552D27af1A7f",
-      "VestingScheme": "0x43FD017320e5f7338Bd48D83D31cF67b147a5770",
-      "VoteInOrganizationScheme": "0x717085B7B8c0Cb36c515E242dC5149DBD347b3a6",
-      "OrganizationRegister": "0xAE79dEd9e9284f9FCd35942Ef6380CEe8c3fd1aA",
-      "Redeemer": "0x8128239aFC8ce0f1c3619a1557DF63daf5D2690e",
-      "GenericScheme": "0x0E5e9086B69Cca78D22682a1e50f5051cbe1B747"
-    },
+    "base": {},
     "dao": {
       "name": "Genesis Test",
       "Avatar": "0xf22Ab662c2201eC9B6c0aD297A6d7fe5034D7723",

--- a/migration.json
+++ b/migration.json
@@ -39,7 +39,25 @@
     }
   },
   "kovan": {
-    "base": {},
+    "base": {
+      "GEN": "0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf",
+      "ControllerCreator": "0xA69a758Ba69d7950D0EBa1d5A0369cD19615D6FF",
+      "DaoCreator": "0x5F16D78245c71dC667a75a7D6c072A5F6991f343",
+      "UController": "0x06D13144685Ae31C8d1004eedc60E8d76C66eAff",
+      "GenesisProtocol": "0x32337118FE4eA5FEb16809374eb6B85b0609752e",
+      "SchemeRegistrar": "0x38830652fc8c749B4E1485f500227b6944563955",
+      "UpgradeScheme": "0xea0EE24517Bb15D6b5E63813a91591926F38Ca0E",
+      "GlobalConstraintRegistrar": "0x1127604d3Acae2Bf87d177123792D4899fd2410b",
+      "ContributionReward": "0x098b1D066cc224593cF996510539692B48b814A1",
+      "AbsoluteVote": "0xfC490CaCCE47728e68CBF03958A955a3fDd58f82",
+      "QuorumVote": "0xDBcaAcf4739f9Fd398150F5d17723C61dD6e19E2",
+      "TokenCapGC": "0x5b30332381E16aF9fb9B3008B8c5552D27af1A7f",
+      "VestingScheme": "0x43FD017320e5f7338Bd48D83D31cF67b147a5770",
+      "VoteInOrganizationScheme": "0x717085B7B8c0Cb36c515E242dC5149DBD347b3a6",
+      "OrganizationRegister": "0xAE79dEd9e9284f9FCd35942Ef6380CEe8c3fd1aA",
+      "Redeemer": "0x8128239aFC8ce0f1c3619a1557DF63daf5D2690e",
+      "GenericScheme": "0x0E5e9086B69Cca78D22682a1e50f5051cbe1B747"
+    },
     "dao": {
       "name": "Genesis Test",
       "Avatar": "0xf22Ab662c2201eC9B6c0aD297A6d7fe5034D7723",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,8 +1248,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "optional": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5407,7 +5406,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {


### PR DESCRIPTION
https://github.com/daostack/migration/issues/54 left the ganache section "DAOToken" where the other networks have "GEN".

This PR corrects to use "GEN" for ganache as well.