### PR TITLE
Network Name Consistency

### DIFF
--- a/migrate-dao.js
+++ b/migrate-dao.js
@@ -2,7 +2,11 @@ const utils = require('./utils.js')
 const sanitize = require('./sanitize')
 
 async function migrateDAO ({ arcVersion, web3, spinner, confirm, opts, migrationParams, logTx, previousMigration, customAbisLocation, restart, getState, setState, cleanState, sendTx, getArcVersionNumber, optimizedAbis }) {
-  const network = await web3.eth.net.getNetworkType()
+  let network = await web3.eth.net.getNetworkType()
+  if (network === 'main') {
+    network = 'mainnet'
+  }
+
   if (restart) {
     cleanState(network)
   }


### PR DESCRIPTION
This makes sure that the network name used by the migration script's `set/get/cleanState` functions is consistent with the network names used in the rest of DAOstack.